### PR TITLE
Remove default logger

### DIFF
--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -483,7 +483,7 @@ def read_tb(path):
     return pandas.DataFrame(data, columns=tags)
 
 # configure the default logger on import
-_configure_default_logger()
+#_configure_default_logger()
 
 if __name__ == "__main__":
     _demo()


### PR DESCRIPTION
Avoid logging to` /tmp/openai_` . 
This default logger is already removed from OpenAI/baselines. This is a working temporal solution until we merge updates from OpenAI.